### PR TITLE
Add support for 'goto' statements, postfix unary operators and increment and decrement operators

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -49,6 +49,7 @@ lazy_static! {
     static ref KEYWORDS: HashMap<&'static str, TokenType> = hash_map! {
         "else"   => TokenType::KElse,
         "for"    => TokenType::KFor,
+        "goto" => TokenType::KGoto,
         "if"     => TokenType::KIf,
         "return" => TokenType::KReturn,
         "while"  => TokenType::KWhile,

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -54,6 +54,7 @@ pub enum TokenType {
 
     KElse,
     KFor,
+    KGoto,
     KIf,
     KReturn,
     KWhile,
@@ -65,10 +66,10 @@ pub enum TokenType {
     EOF,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Span(pub usize, pub usize);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     pub span: Span,
     pub line: usize,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -3,7 +3,7 @@ pub use super::stmt::*;
 use crate::lexer::token::Token;
 use std::ops::{Deref, DerefMut};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WithToken<T>(pub T, pub Token);
 
 impl<T> WithToken<T> {
@@ -74,7 +74,9 @@ pub trait ASTRefVisitor:
     fn visit_stmt(&mut self, stmt: &Stmt) -> Self::StmtResult {
         match stmt {
             Stmt::Expression(expr) => self.visit_expression(expr),
+            Stmt::Goto(label) => self.visit_goto(label),
             Stmt::If(if_stmt) => self.visit_if(if_stmt),
+            Stmt::Label(label) => self.visit_label(label),
             Stmt::Null => self.visit_null(),
             Stmt::Return { ret_value } => self.visit_return(ret_value),
         }
@@ -110,7 +112,9 @@ pub trait ASTVisitor: StmtVisitor<Self::StmtResult> + ExprVisitor<Self::ExprResu
     fn visit_stmt(&mut self, stmt: Stmt) -> Self::StmtResult {
         match stmt {
             Stmt::Expression(expr) => self.visit_expression(expr),
+            Stmt::Goto(label) => self.visit_goto(label),
             Stmt::If(if_stmt) => self.visit_if(if_stmt),
+            Stmt::Label(label) => self.visit_label(label),
             Stmt::Null => self.visit_null(),
             Stmt::Return { ret_value } => self.visit_return(ret_value),
         }

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -32,6 +32,7 @@ pub struct Binary {
 pub struct Unary {
     pub op: WithToken<UnaryOp>,
     pub expr: Box<Expr>,
+    pub postfix: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -46,6 +47,8 @@ pub enum UnaryOp {
     Minus,
     Not,
     BitNOT,
+    Increment,
+    Decrement,
 }
 
 impl Display for UnaryOp {
@@ -54,6 +57,8 @@ impl Display for UnaryOp {
             UnaryOp::Minus => "-",
             UnaryOp::Not => "!",
             UnaryOp::BitNOT => "~",
+            UnaryOp::Increment => "++",
+            UnaryOp::Decrement => "--",
         };
         write!(f, "{}", op)
     }

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -1,4 +1,4 @@
-use super::expr::Expr;
+use super::{expr::Expr, WithToken};
 
 #[derive(Debug)]
 pub struct IfStmt {
@@ -8,23 +8,35 @@ pub struct IfStmt {
 }
 
 #[derive(Debug)]
+pub struct Label {
+    pub name: WithToken<String>,
+    pub next_stmt: Box<Stmt>,
+}
+
+#[derive(Debug)]
 pub enum Stmt {
     Expression(Expr),
+    Goto(WithToken<String>),
     If(IfStmt),
+    Label(Label),
     Null,
     Return { ret_value: Expr },
 }
 
 pub trait StmtRefVisitor<R> {
     fn visit_expression(&mut self, expr: &Expr) -> R;
+    fn visit_goto(&mut self, label: &WithToken<String>) -> R;
     fn visit_if(&mut self, if_stmt: &IfStmt) -> R;
+    fn visit_label(&mut self, label: &Label) -> R;
     fn visit_null(&mut self) -> R;
     fn visit_return(&mut self, ret_value: &Expr) -> R;
 }
 
 pub trait StmtVisitor<R> {
     fn visit_expression(&mut self, expr: Expr) -> R;
+    fn visit_goto(&mut self, label: WithToken<String>) -> R;
     fn visit_if(&mut self, if_stmt: IfStmt) -> R;
+    fn visit_label(&mut self, label: Label) -> R;
     fn visit_null(&mut self) -> R;
     fn visit_return(&mut self, ret_value: Expr) -> R;
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -81,6 +81,7 @@ impl ExprVisitor<ResolveResult<Expr>> for Resolver {
         Ok(Expr::Unary(Unary {
             op: expr.op,
             expr: Box::new(self.visit_expr(*expr.expr)?),
+            postfix: expr.postfix,
         }))
     }
 
@@ -101,6 +102,10 @@ impl StmtVisitor<ResolveResult<Stmt>> for Resolver {
         Ok(Stmt::Expression(self.visit_expr(expr)?))
     }
 
+    fn visit_goto(&mut self, label: WithToken<String>) -> ResolveResult<Stmt> {
+        Ok(Stmt::Goto(label))
+    }
+
     fn visit_if(&mut self, if_stmt: IfStmt) -> ResolveResult<Stmt> {
         Ok(Stmt::If(IfStmt {
             cond: self.visit_expr(if_stmt.cond)?,
@@ -110,6 +115,13 @@ impl StmtVisitor<ResolveResult<Stmt>> for Resolver {
                 .map(|ec| self.visit_stmt(*ec))
                 .transpose()?
                 .map(Box::new),
+        }))
+    }
+
+    fn visit_label(&mut self, label: Label) -> ResolveResult<Stmt> {
+        Ok(Stmt::Label(Label {
+            name: label.name,
+            next_stmt: Box::new(self.visit_stmt(*label.next_stmt)?),
         }))
     }
 


### PR DESCRIPTION
This pull request includes several changes to the codebase, primarily focused on enhancing the parser functionality, adding support for new unary operations, and improving the handling of labels and gotos. The most important changes include modifications to the `UnaryOp` and `BinaryOp` enums, updates to the `Instruction` implementation, and the introduction of label and goto handling in the parser.

### Parser Enhancements:

* Added support for `Increment` and `Decrement` operations in the `UnaryOp` enum and updated the parser to handle these new operations. (`src/parser/expr.rs`, `src/parser/mod.rs`) [[1]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649L248-R248) [[2]](diffhunk://#diff-1a71e483a2705fca4bf7709c33d4b41adf43caf887b12a46f413d6b921b227a1R50-R51) [[3]](diffhunk://#diff-1a71e483a2705fca4bf7709c33d4b41adf43caf887b12a46f413d6b921b227a1R60-R61) [[4]](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49L367-R399) [[5]](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49R544-R545)
* Introduced label and goto handling in the parser, including new methods for parsing labels and goto statements. (`src/parser/ast.rs`, `src/parser/mod.rs`, `src/parser/stmt.rs`) [[1]](diffhunk://#diff-b78363c945458ba512de20a9df6c5b2536b373fd115e181701f89ee0e7acf6d3R77-R79) [[2]](diffhunk://#diff-b78363c945458ba512de20a9df6c5b2536b373fd115e181701f89ee0e7acf6d3R115-R117) [[3]](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49R458-R486) [[4]](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49R516-R532)

### Codebase Simplification:

* Updated the `Instruction` implementation to optimize the handling of binary operations by avoiding unnecessary moves. (`src/asm.rs`)
* Added `PartialEq` and `Eq` derives to several enums and structs to facilitate comparisons. (`src/asm.rs`, `src/lexer/token.rs`, `src/parser/ast.rs`) [[1]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649L481-R490) [[2]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649L512-R521) [[3]](diffhunk://#diff-d417470a8403d56521df4a86a0be785c8970dac490fc17e1a06f8da43ea32d91L68-R72) [[4]](diffhunk://#diff-b78363c945458ba512de20a9df6c5b2536b373fd115e181701f89ee0e7acf6d3L6-R6)

### Lexer and Token Updates:

* Added the `goto` keyword to the lexer and updated the `TokenType` enum accordingly. (`src/lexer/mod.rs`, `src/lexer/token.rs`) [[1]](diffhunk://#diff-38925686e9d8d144d9f852e93c0cafe472f340651a5ffbbdd705c0f80265987cR52) [[2]](diffhunk://#diff-d417470a8403d56521df4a86a0be785c8970dac490fc17e1a06f8da43ea32d91R57)

### Pretty Print Enhancements:

* Enhanced the pretty print functionality to handle new unary operations and label/goto statements. (`src/parser/pretty_print_ast.rs`) [[1]](diffhunk://#diff-d9d8baaf7bad9777aceb7650afc6ef7c4507b8ab59f4135b883cac8b4f9e4aadL102-R115) [[2]](diffhunk://#diff-d9d8baaf7bad9777aceb7650afc6ef7c4507b8ab59f4135b883cac8b4f9e4aadR139-R147) [[3]](diffhunk://#diff-d9d8baaf7bad9777aceb7650afc6ef7c4507b8ab59f4135b883cac8b4f9e4aadR172-R184)

### Resolver Updates:

* Updated the resolver to handle new unary operations and label/goto statements. (`src/resolver.rs`) [[1]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR84) [[2]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR105-R108) [[3]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR121-R127)