### PR TITLE
Added debug info in generated assembly files

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
+use crate::debug_info::{DebugInfo, WithDebugInfo};
 use crate::parser::ast::{self, BinaryOp, UnaryOp};
 use crate::tacky;
 
@@ -74,7 +75,7 @@ impl Program {
         for def in self.defs.iter_mut() {
             let mut pseudo_map = HashMap::new();
             for inst in def.body.iter_mut() {
-                match inst {
+                match &mut **inst {
                     Instruction::Mov { src, dest } => {
                         replace_pseudo_operand!(self, src, pseudo_map);
                         replace_pseudo_operand!(self, dest, pseudo_map);
@@ -109,81 +110,103 @@ impl Program {
     fn alloc_stack_and_resolve_stack_ops(&mut self) {
         for def in self.defs.iter_mut() {
             if def.stack_size > 0 {
-                def.body
-                    .insert(0, Instruction::AllocateStack(def.stack_size));
+                def.body.insert(
+                    0,
+                    WithDebugInfo::new(
+                        Instruction::AllocateStack(def.stack_size),
+                        DebugInfo {
+                            line: 0,
+                            description: "".to_string(),
+                        },
+                    ),
+                );
             }
 
             let mut index = 0;
             while index < def.body.len() {
                 match def.body[index].clone() {
-                    Instruction::Mov {
-                        src: Operand::Stack(src),
-                        dest: Operand::Stack(dest),
-                    } => {
-                        replace_instruction!(def.body; [index] =>
+                    WithDebugInfo {
+                        value:
                             Instruction::Mov {
                                 src: Operand::Stack(src),
-                                dest: Operand::Reg(Register::R10),
+                                dest: Operand::Stack(dest),
                             },
-                            Instruction::Mov {
+                        debug_info,
+                    } => {
+                        replace_instruction!(def.body; [index] =>
+                            WithDebugInfo::new(Instruction::Mov {
+                                src: Operand::Stack(src),
+                                dest: Operand::Reg(Register::R10),
+                            }, DebugInfo { line: debug_info.line, description: format!("({}) (stack mov {} -> {}) {} -> r10 (temp)", debug_info.description, src, dest, src) }),
+                            WithDebugInfo::new(Instruction::Mov {
                                 src: Operand::Reg(Register::R10),
                                 dest: Operand::Stack(dest),
-                            }
+                            }, DebugInfo { line: debug_info.line, description: format!("({}) (stack mov {} -> {}) r10 -> {}", debug_info.description, src, dest, dest) })
                         );
                     }
-                    Instruction::Binary(op, Operand::Stack(val), Operand::Stack(src))
-                        if REGULAR_BINARY_OPS.contains(&op) =>
-                    {
+                    WithDebugInfo {
+                        value: Instruction::Binary(op, Operand::Stack(val), Operand::Stack(src)),
+                        debug_info,
+                    } if REGULAR_BINARY_OPS.contains(&op) => {
                         // addq -m(%rbp), -n(%rbp)
                         // ---
                         // movq -m(%rbp), %r10
                         // addl %r10, -n(%rbp)
                         replace_instruction!(def.body; [index] =>
-                            Instruction::Mov {
+                            WithDebugInfo::new(Instruction::Mov {
                                 src: Operand::Stack(val),
                                 dest: Operand::Reg(Register::R10),
-                            },
-                            Instruction::Binary(
+                            }, DebugInfo{ line: debug_info.line, description: format!("({}) (stack binary {} {} {}) {} -> r10 (temp)", debug_info.description, src, op, val, val) }),
+                            WithDebugInfo::new(Instruction::Binary(
                                 op,
                                 Operand::Reg(Register::R10),
                                 Operand::Stack(src),
-                            )
+                            ), DebugInfo { line: debug_info.line, description: format!("({}) (stack binary {} {} {}) r10 -> {}", debug_info.description, src, op, val, src) })
                         );
                     }
-                    Instruction::Binary(BinaryOp::Mul, rhs, lhs @ Operand::Stack(_)) => {
+                    WithDebugInfo {
+                        value: Instruction::Binary(BinaryOp::Mul, rhs, lhs @ Operand::Stack(n)),
+                        debug_info,
+                    } => {
                         // imulq $3, -4(%rbp)
                         // ---
                         // movq -4(%rbp), %r11
                         // imulq $3, %r11
                         // movq %r11, -4(%rbp)
                         replace_instruction!(def.body; [index] =>
-                            Instruction::Mov {
+                            WithDebugInfo::new(Instruction::Mov {
                                 src: lhs.clone(),
                                 dest: Operand::Reg(Register::R11),
-                            },
-                            Instruction::Binary(BinaryOp::Mul, rhs, Operand::Reg(Register::R11)),
-                            Instruction::Mov {
+                            }, DebugInfo{ line: debug_info.line, description: format!("({}) (mul on stack {}) {} -> r11", debug_info.description, n, n) }),
+                            WithDebugInfo::new(Instruction::Binary(BinaryOp::Mul, rhs, Operand::Reg(Register::R11)),  debug_info.clone()),
+                            WithDebugInfo::new(Instruction::Mov {
                                 src: Operand::Reg(Register::R11),
                                 dest: lhs,
-                            }
+                            }, DebugInfo{ line: debug_info.line, description: format!("({}) (mul on stack {}) r11 -> {}", debug_info.description, n, n) })
                         );
                     }
-                    Instruction::Cmp(op1 @ Operand::Stack(_), op2 @ Operand::Stack(_)) => {
+                    WithDebugInfo {
+                        value: Instruction::Cmp(op1 @ Operand::Stack(n1), op2 @ Operand::Stack(n2)),
+                        debug_info,
+                    } => {
                         replace_instruction!(def.body; [index] =>
-                            Instruction::Mov {
+                            WithDebugInfo::new(Instruction::Mov {
                                 src: op1,
                                 dest: Operand::Reg(Register::R11),
-                            },
-                            Instruction::Cmp(Operand::Reg(Register::R11), op2)
+                            }, DebugInfo{ line: debug_info.line, description: format!("({}) (stack cmp {} {}) {} -> r11", debug_info.description, n1, n2, n1) }),
+                            WithDebugInfo::new(Instruction::Cmp(Operand::Reg(Register::R11), op2), DebugInfo{ line: debug_info.line, description: format!("({}) (stack cmp {} {})", debug_info.description, n1, n2) })
                         );
                     }
-                    Instruction::Cmp(op1, op2 @ Operand::Imm(_)) => {
+                    WithDebugInfo {
+                        value: Instruction::Cmp(op1, op2 @ Operand::Imm(n)),
+                        debug_info,
+                    } => {
                         replace_instruction!(def.body; [index] =>
-                            Instruction::Mov {
+                            WithDebugInfo::new(Instruction::Mov {
                                 src: op2,
                                 dest: Operand::Reg(Register::R11),
-                            },
-                            Instruction::Cmp(op1, Operand::Reg(Register::R11))
+                            }, DebugInfo{ line: debug_info.line, description: format!("({}) (cmp with imm) ${} -> r11", debug_info.description, n) }),
+                            WithDebugInfo::new(Instruction::Cmp(op1, Operand::Reg(Register::R11)), DebugInfo{ line: debug_info.line, description: format!("({}) (cmp with imm)", debug_info.description) })
                         );
                     }
                     _ => {}
@@ -206,7 +229,7 @@ impl From<&tacky::Program> for Program {
 #[derive(Debug)]
 pub struct FunctionDef {
     name: String,
-    body: Vec<Instruction>,
+    body: Vec<WithDebugInfo<Instruction>>,
     stack_size: i32,
 }
 
@@ -219,7 +242,7 @@ impl FunctionDef {
             indent(&["pushq\t%rbp", "movq\t%rsp, %rbp"]),
             self.body
                 .iter()
-                .map(|s| s.to_asm_string())
+                .map(|s| to_asm_string(s))
                 .collect::<Vec<String>>()
                 .join(&format!("\n{}", INDENT))
         )
@@ -330,110 +353,221 @@ pub enum Instruction {
 }
 
 impl Instruction {
-    fn to_asm_string(&self) -> String {
-        match self {
-            Instruction::AllocateStack(n) => format!("subq\t${}, %rsp", n),
-            Instruction::Mov { src, dest } => {
-                format!("movq\t{}, {}", src.to_asm_string(), dest.to_asm_string())
-            }
-            Instruction::Unary(op, operand) => {
-                format!("{}\t{}", unary_op_to_asm(op), operand.to_asm_string())
-            }
-            Instruction::Binary(op, val, src) => {
-                format!(
-                    "{:<4}\t{}, {}",
-                    binary_op_to_asm(op),
-                    val.to_asm_string(),
-                    src.to_asm_string()
-                )
-            }
-            Instruction::Cmp(lhs, rhs) => {
-                format!("cmpq\t{}, {}", lhs.to_asm_string(), rhs.to_asm_string())
-            }
-            Instruction::Label(label) => format!("{}:", label),
-            Instruction::Jmp(target) => format!("jmp\t\t{}", target),
-            Instruction::JmpCC(op, target) => format!("j{}\t{}", op, target),
-            Instruction::SetCC(op, dest) => format!("set{}\t{}", op, dest.to_asm_string()),
-            Instruction::Cqo => "cqo".to_string(),
-            Instruction::Idiv(operand) => format!("idivq\t{}", operand.to_asm_string()),
-            Instruction::Ret => indent(&["movq\t%rbp, %rsp", "popq\t%rbp", "ret"]),
-        }
-    }
+    // fn to_asm_string(&self) -> String {
+    //     match self {
+    //         Instruction::AllocateStack(n) => format!("subq\t${}, %rsp", n),
+    //         Instruction::Mov { src, dest } => {
+    //             format!("movq\t{}, {}", src.to_asm_string(), dest.to_asm_string())
+    //         }
+    //         Instruction::Unary(op, operand) => {
+    //             format!("{}\t{}", unary_op_to_asm(op), operand.to_asm_string())
+    //         }
+    //         Instruction::Binary(op, val, src) => {
+    //             format!(
+    //                 "{:<4}\t{}, {}",
+    //                 binary_op_to_asm(op),
+    //                 val.to_asm_string(),
+    //                 src.to_asm_string()
+    //             )
+    //         }
+    //         Instruction::Cmp(lhs, rhs) => {
+    //             format!("cmpq\t{}, {}", lhs.to_asm_string(), rhs.to_asm_string())
+    //         }
+    //         Instruction::Label(label) => format!("{}:", label),
+    //         Instruction::Jmp(target) => format!("jmp\t\t{}", target),
+    //         Instruction::JmpCC(op, target) => format!("j{}\t{}", op, target),
+    //         Instruction::SetCC(op, dest) => format!("set{}\t{}", op, dest.to_asm_string()),
+    //         Instruction::Cqo => "cqo".to_string(),
+    //         Instruction::Idiv(operand) => format!("idivq\t{}", operand.to_asm_string()),
+    //         Instruction::Ret => indent(&["movq\t%rbp, %rsp", "popq\t%rbp", "ret"]),
+    //     }
+    // }
 
-    fn generate(inst: &tacky::Instruction, body: &mut Vec<Instruction>) {
+    fn generate(
+        inst: &WithDebugInfo<tacky::Instruction>,
+        body: &mut Vec<WithDebugInfo<Instruction>>,
+    ) {
         match inst {
-            tacky::Instruction::Return(value) => {
-                let value = Operand::from(value);
-                body.push(Instruction::Mov {
-                    src: value,
-                    dest: Operand::Reg(Register::RAX),
-                });
-                body.push(Instruction::Ret);
+            WithDebugInfo {
+                value: tacky::Instruction::Return(val),
+                debug_info,
+            } => {
+                let value = Operand::from(val);
+                body.push(WithDebugInfo::new(
+                    Instruction::Mov {
+                        src: value,
+                        dest: Operand::Reg(Register::RAX),
+                    },
+                    DebugInfo {
+                        line: debug_info.line,
+                        description: format!(
+                            "({}) ret {}",
+                            debug_info.description,
+                            val.to_string()
+                        ),
+                    },
+                ));
+                body.push(WithDebugInfo::new(Instruction::Ret, debug_info.clone()));
             }
-            tacky::Instruction::Copy { src, dst } => {
-                body.push(Instruction::Mov {
-                    src: Operand::from(src),
-                    dest: Operand::from(dst),
-                });
+            WithDebugInfo {
+                value: tacky::Instruction::Copy { src, dst },
+                debug_info,
+            } => {
+                body.push(WithDebugInfo::new(
+                    Instruction::Mov {
+                        src: Operand::from(src),
+                        dest: Operand::from(dst),
+                    },
+                    DebugInfo {
+                        line: debug_info.line,
+                        description: format!(
+                            "({}) {} -> {}",
+                            debug_info.description,
+                            src.to_string(),
+                            dst.to_string()
+                        ),
+                    },
+                ));
             }
-            tacky::Instruction::Unary(op, src, dest) => {
-                let src = Operand::from(src);
-                let dest = Operand::from(dest);
+            WithDebugInfo {
+                value: tacky::Instruction::Unary(op, src_, dest_),
+                debug_info,
+            } => {
+                let src = Operand::from(src_);
+                let dest = Operand::from(dest_);
                 match op {
                     UnaryOp::Not => {
                         body.extend_from_slice(&[
-                            Instruction::Cmp(Operand::Imm(0), src),
-                            Instruction::Mov {
-                                src: Operand::Imm(0),
-                                dest: dest.clone(),
-                            },
-                            Instruction::SetCC(CondCode::E, dest),
+                            WithDebugInfo::new(
+                                Instruction::Cmp(Operand::Imm(0), src),
+                                debug_info.map_description_ref(|d| {
+                                    format!("({}) unary ! {}", d, src_.to_string())
+                                }),
+                            ),
+                            WithDebugInfo::new(
+                                Instruction::Mov {
+                                    src: Operand::Imm(0),
+                                    dest: dest.clone(),
+                                },
+                                debug_info.map_description_ref(|d| {
+                                    format!("({}) unary ! {}", d, src_.to_string())
+                                }),
+                            ),
+                            WithDebugInfo::new(
+                                Instruction::SetCC(CondCode::E, dest),
+                                debug_info.map_description_ref(|d| {
+                                    format!("({}) unary ! {}", d, src_.to_string())
+                                }),
+                            ),
                         ]);
                     }
                     _ => {
                         body.extend_from_slice(&[
-                            Instruction::Mov {
-                                src,
-                                dest: dest.clone(),
-                            },
-                            Instruction::Unary(*op, dest),
+                            WithDebugInfo::new(
+                                Instruction::Mov {
+                                    src,
+                                    dest: dest.clone(),
+                                },
+                                debug_info.map_description_ref(|d| {
+                                    format!("({}) unary {} {}", d, op, src_.to_string())
+                                }),
+                            ),
+                            WithDebugInfo::new(Instruction::Unary(*op, dest), debug_info.clone()),
                         ]);
                     }
                 }
             }
-            tacky::Instruction::Binary(op, vlhs, vrhs, dest) => {
-                let vlhs = Operand::from(vlhs);
-                let mut vrhs = Operand::from(vrhs);
+            WithDebugInfo {
+                value: tacky::Instruction::Binary(op, vlhs_, vrhs_, dest),
+                debug_info,
+            } => {
+                let vlhs = Operand::from(vlhs_);
+                let mut vrhs = Operand::from(vrhs_);
                 let dest = Operand::from(dest);
                 match op {
                     BinaryOp::Mod | BinaryOp::Div => {
-                        let result_reg = if let BinaryOp::Div = op {
-                            Operand::Reg(Register::RAX)
+                        let (result_reg, inst) = if let BinaryOp::Div = op {
+                            (Operand::Reg(Register::RAX), "div")
                         } else {
-                            Operand::Reg(Register::RDX)
+                            (Operand::Reg(Register::RDX), "mod")
                         };
                         body.extend_from_slice(&[
-                            Instruction::Mov {
-                                src: vlhs,
-                                dest: Operand::Reg(Register::RAX),
-                            },
-                            Instruction::Cqo,
+                            WithDebugInfo::new(
+                                Instruction::Mov {
+                                    src: vlhs,
+                                    dest: Operand::Reg(Register::RAX),
+                                },
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        inst,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ),
+                            WithDebugInfo::new(
+                                Instruction::Cqo,
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        op,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ),
                         ]);
 
                         if let Operand::Imm(_) = vrhs {
-                            body.push(Instruction::Mov {
-                                src: vrhs,
-                                dest: Operand::Reg(Register::R10),
-                            });
+                            body.push(WithDebugInfo::new(
+                                Instruction::Mov {
+                                    src: vrhs,
+                                    dest: Operand::Reg(Register::R10),
+                                },
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        op,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ));
                             vrhs = Operand::Reg(Register::R10);
                         }
 
                         body.extend_from_slice(&[
-                            Instruction::Idiv(vrhs),
-                            Instruction::Mov {
-                                src: result_reg,
-                                dest,
-                            },
+                            WithDebugInfo::new(
+                                Instruction::Idiv(vrhs),
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        op,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ),
+                            WithDebugInfo::new(
+                                Instruction::Mov {
+                                    src: result_reg,
+                                    dest,
+                                },
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        op,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ),
                         ]);
                     }
                     BinaryOp::Eq
@@ -443,48 +577,162 @@ impl Instruction {
                     | BinaryOp::Greater
                     | BinaryOp::GreaterEq => {
                         body.extend_from_slice(&[
-                            Instruction::Cmp(vrhs, vlhs),
-                            Instruction::Mov {
-                                src: Operand::Imm(0),
-                                dest: dest.clone(),
-                            },
-                            Instruction::SetCC(op.into(), dest),
+                            WithDebugInfo::new(
+                                Instruction::Cmp(vrhs, vlhs),
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        op,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ),
+                            WithDebugInfo::new(
+                                Instruction::Mov {
+                                    src: Operand::Imm(0),
+                                    dest: dest.clone(),
+                                },
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        op,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ),
+                            WithDebugInfo::new(
+                                Instruction::SetCC(op.into(), dest),
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        op,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ),
                         ]);
                     }
                     _ => {
                         if vlhs != dest {
-                            body.push(Instruction::Mov {
-                                src: vlhs,
-                                dest: dest.clone(),
-                            });
+                            body.push(WithDebugInfo::new(
+                                Instruction::Mov {
+                                    src: vlhs,
+                                    dest: dest.clone(),
+                                },
+                                debug_info.map_description_ref(|d| {
+                                    format!(
+                                        "({}) {} {} {}",
+                                        d,
+                                        op,
+                                        vlhs_.to_string(),
+                                        vrhs_.to_string()
+                                    )
+                                }),
+                            ));
                         }
-                        body.push(Instruction::Binary(*op, vrhs, dest));
+                        body.push(WithDebugInfo::new(
+                            Instruction::Binary(*op, vrhs, dest),
+                            debug_info.map_description_ref(|d| {
+                                format!(
+                                    "({}) {} {} {}",
+                                    d,
+                                    op,
+                                    vlhs_.to_string(),
+                                    vrhs_.to_string()
+                                )
+                            }),
+                        ));
                     }
                 }
             }
-            tacky::Instruction::Jump(label) => {
-                body.push(Instruction::Jmp(label.clone()));
+            WithDebugInfo {
+                value: tacky::Instruction::Jump(label),
+                debug_info,
+            } => {
+                body.push(WithDebugInfo::new(
+                    Instruction::Jmp(label.clone()),
+                    debug_info.clone(),
+                ));
             }
 
-            tacky::Instruction::JumpIfZero(val, target) => {
+            WithDebugInfo {
+                value: tacky::Instruction::JumpIfZero(val, target),
+                debug_info,
+            } => {
                 let val = Operand::from(val);
                 body.extend_from_slice(&[
-                    Instruction::Cmp(Operand::Imm(0), val),
-                    Instruction::JmpCC(CondCode::E, target.clone()),
+                    WithDebugInfo::new(Instruction::Cmp(Operand::Imm(0), val), debug_info.clone()),
+                    WithDebugInfo::new(
+                        Instruction::JmpCC(CondCode::E, target.clone()),
+                        debug_info.clone(),
+                    ),
                 ]);
             }
 
-            tacky::Instruction::JumpIfNotZero(val, target) => {
+            WithDebugInfo {
+                value: tacky::Instruction::JumpIfNotZero(val, target),
+                debug_info,
+            } => {
                 let val = Operand::from(val);
                 body.extend_from_slice(&[
-                    Instruction::Cmp(Operand::Imm(0), val),
-                    Instruction::JmpCC(CondCode::NE, target.clone()),
+                    WithDebugInfo::new(Instruction::Cmp(Operand::Imm(0), val), debug_info.clone()),
+                    WithDebugInfo::new(
+                        Instruction::JmpCC(CondCode::NE, target.clone()),
+                        debug_info.clone(),
+                    ),
                 ]);
             }
 
-            tacky::Instruction::Label(label) => body.push(Instruction::Label(label.clone())),
+            WithDebugInfo {
+                value: tacky::Instruction::Label(label),
+                debug_info,
+            } => body.push(WithDebugInfo::new(
+                Instruction::Label(label.clone()),
+                debug_info.clone(),
+            )),
         }
     }
+}
+
+fn to_asm_string(inst: &WithDebugInfo<Instruction>) -> String {
+    let comment = format!(
+        "# line {} :: {}",
+        inst.debug_info.line, inst.debug_info.description
+    );
+    let asm = match &inst.value {
+        Instruction::AllocateStack(n) => format!("subq\t${}, %rsp", n),
+        Instruction::Mov { src, dest } => {
+            format!("movq\t{}, {}", src.to_asm_string(), dest.to_asm_string())
+        }
+        Instruction::Unary(op, operand) => {
+            format!("{}\t{}", unary_op_to_asm(op), operand.to_asm_string())
+        }
+        Instruction::Binary(op, val, src) => {
+            format!(
+                "{:<4}\t{}, {}",
+                binary_op_to_asm(op),
+                val.to_asm_string(),
+                src.to_asm_string()
+            )
+        }
+        Instruction::Cmp(lhs, rhs) => {
+            format!("cmpq\t{}, {}", lhs.to_asm_string(), rhs.to_asm_string())
+        }
+        Instruction::Label(label) => format!("{}:", label),
+        Instruction::Jmp(target) => format!("jmp\t\t{}", target),
+        Instruction::JmpCC(op, target) => format!("j{}\t{}", op, target),
+        Instruction::SetCC(op, dest) => format!("set{}\t{}", op, dest.to_asm_string()),
+        Instruction::Cqo => "cqo".to_string(),
+        Instruction::Idiv(operand) => format!("idivq\t{}", operand.to_asm_string()),
+        Instruction::Ret => indent(&["movq\t%rbp, %rsp", "popq\t%rbp", "ret"]),
+    };
+    format!("{}\t{}", asm, comment)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -1,0 +1,69 @@
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+#[derive(Debug, Clone)]
+pub struct DebugInfo {
+    pub line: usize,
+    pub description: String,
+}
+
+impl DebugInfo {
+    pub fn map_description(self, f: impl FnOnce(String) -> String) -> Self {
+        Self {
+            line: self.line,
+            description: f(self.description),
+        }
+    }
+
+    pub fn map_description_ref(&self, f: impl FnOnce(&String) -> String) -> Self {
+        Self {
+            line: self.line,
+            description: f(&self.description),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WithDebugInfo<T> {
+    pub value: T,
+    pub debug_info: DebugInfo,
+}
+
+impl<T> WithDebugInfo<T> {
+    pub fn new(value: T, debug_info: DebugInfo) -> Self {
+        Self { value, debug_info }
+    }
+
+    pub fn unwrap(self) -> T {
+        self.value
+    }
+
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+
+    pub fn get_debug_info(&self) -> &DebugInfo {
+        &self.debug_info
+    }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> WithDebugInfo<U> {
+        WithDebugInfo {
+            value: f(self.value),
+            debug_info: self.debug_info,
+        }
+    }
+}
+
+impl<T> Deref for WithDebugInfo<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<T> DerefMut for WithDebugInfo<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod asm;
+pub mod debug_info;
 pub mod lexer;
 pub mod parser;
 pub mod resolver;

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -18,6 +18,22 @@ impl<T> WithToken<T> {
     pub fn replace(&mut self, new_val: T) -> T {
         std::mem::replace(&mut self.0, new_val)
     }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> WithToken<U> {
+        WithToken(f(self.0), self.1)
+    }
+}
+
+impl<T, E> WithToken<Result<T, E>> {
+    pub fn transpose(self) -> Result<WithToken<T>, E> {
+        self.0.map(|t| WithToken(t, self.1))
+    }
+}
+
+impl<T> WithToken<Option<T>> {
+    pub fn transpose(self) -> Option<WithToken<T>> {
+        self.0.map(|t| WithToken(t, self.1))
+    }
 }
 
 impl<T> Deref for WithToken<T> {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -40,6 +40,8 @@ pub struct Conditional {
     pub cond: Box<Expr>,
     pub then_expr: Box<Expr>,
     pub else_expr: Box<Expr>,
+    pub qmark: Token,
+    pub colon: Token,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/src/parser/pretty_print_ast.rs
+++ b/src/parser/pretty_print_ast.rs
@@ -204,7 +204,7 @@ impl StmtRefVisitor<String> for PrettyPrint {
         format!("{}{}", Self::INDENT.repeat(self.indent), "NULL".red())
     }
 
-    fn visit_return(&mut self, ret_value: &Expr) -> String {
+    fn visit_return(&mut self, ret_value: &WithToken<Expr>) -> String {
         self.indent += 1;
         let ret_str = format!(
             "{}{} \x0b{}",

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -2,9 +2,9 @@ use super::{expr::Expr, BlockItem, WithToken};
 
 #[derive(Debug)]
 pub struct IfStmt {
-    pub cond: Expr,
+    pub cond: WithToken<Expr>,
     pub then: Box<Stmt>,
-    pub else_clause: Option<Box<Stmt>>,
+    pub else_clause: Option<Box<WithToken<Stmt>>>,
 }
 
 #[derive(Debug)]
@@ -24,7 +24,7 @@ pub enum Stmt {
     If(IfStmt),
     Label(Label),
     Null,
-    Return { ret_value: Expr },
+    Return { ret_value: WithToken<Expr> },
 }
 
 pub trait StmtRefVisitor<R> {
@@ -34,7 +34,7 @@ pub trait StmtRefVisitor<R> {
     fn visit_if(&mut self, if_stmt: &IfStmt) -> R;
     fn visit_label(&mut self, label: &Label) -> R;
     fn visit_null(&mut self) -> R;
-    fn visit_return(&mut self, ret_value: &Expr) -> R;
+    fn visit_return(&mut self, ret_value: &WithToken<Expr>) -> R;
 }
 
 pub trait StmtVisitor<R> {
@@ -44,5 +44,5 @@ pub trait StmtVisitor<R> {
     fn visit_if(&mut self, if_stmt: IfStmt) -> R;
     fn visit_label(&mut self, label: Label) -> R;
     fn visit_null(&mut self) -> R;
-    fn visit_return(&mut self, ret_value: Expr) -> R;
+    fn visit_return(&mut self, ret_value: WithToken<Expr>) -> R;
 }

--- a/src/tacky.rs
+++ b/src/tacky.rs
@@ -1,3 +1,4 @@
+use crate::debug_info::{DebugInfo, WithDebugInfo};
 use crate::parser::ast::{
     self, ASTRefVisitor, BinaryOp, BlockItem, ExprRefVisitor, Literal, StmtRefVisitor, WithToken,
 };
@@ -8,7 +9,7 @@ pub struct Program(pub Vec<FunctionDef>);
 #[derive(Debug)]
 pub struct FunctionDef {
     pub name: String,
-    pub body: Vec<Instruction>,
+    pub body: Vec<WithDebugInfo<Instruction>>,
 }
 
 pub type Target = String;
@@ -31,10 +32,20 @@ pub enum Value {
     Var(String),
 }
 
+impl Value {
+    pub fn to_string(&self) -> String {
+        match self {
+            Value::Literal(Literal::Integer(i)) => format!("${}", i),
+            Value::Literal(Literal::Float(f)) => format!("${}", f),
+            Value::Var(name) => name.clone(),
+        }
+    }
+}
+
 pub struct GenerateTacky {
     var_counter: i32,
     label_counter: i32,
-    current_body: Vec<Instruction>,
+    current_body: Vec<WithDebugInfo<Instruction>>,
 }
 
 impl GenerateTacky {
@@ -56,6 +67,11 @@ impl GenerateTacky {
         self.label_counter += 1;
         format!("l.{}.{}", desc, self.label_counter - 1)
     }
+
+    fn push_inst(&mut self, line: usize, description: String, inst: Instruction) {
+        self.current_body
+            .push(WithDebugInfo::new(inst, DebugInfo { line, description }));
+    }
 }
 
 impl ExprRefVisitor<Value> for GenerateTacky {
@@ -63,15 +79,33 @@ impl ExprRefVisitor<Value> for GenerateTacky {
         let result = self.visit_expr(&expr.rhs);
         // lhs guarateed to be Var(_), so dst will be a Value::Var(_)
         let dest = self.visit_expr(&expr.lhs);
-        self.current_body.push(Instruction::Copy {
-            src: result,
-            dst: dest.clone(),
-        });
+
+        let debug_info = DebugInfo {
+            line: expr.eq_sign.line,
+            description: format!(
+                "(assignment) `{}` ({}) = {} (result)",
+                if let Value::Var(ref name) = dest {
+                    name
+                } else {
+                    unreachable!()
+                },
+                dest.to_string(),
+                result.to_string()
+            ),
+        };
+        self.current_body.push(WithDebugInfo::new(
+            Instruction::Copy {
+                src: result,
+                dst: dest.clone(),
+            },
+            debug_info,
+        ));
         dest
     }
 
     fn visit_binary(&mut self, expr: &ast::Binary) -> Value {
         let ast::Binary { op, lhs, rhs } = expr;
+        let line = expr.op.1.line;
         match **op {
             BinaryOp::And => {
                 let dst = self.new_var();
@@ -79,24 +113,43 @@ impl ExprRefVisitor<Value> for GenerateTacky {
                 let end_label = self.new_label("and_end");
 
                 let vlhs = self.visit_expr(lhs);
-                self.current_body
-                    .push(Instruction::JumpIfZero(vlhs, false_label.clone()));
+                self.push_inst(
+                    line,
+                    format!("(&&) when lhs `{}` is false", vlhs.to_string()),
+                    Instruction::JumpIfZero(vlhs, false_label.clone()),
+                );
+
                 let vrhs = self.visit_expr(rhs);
-                self.current_body
-                    .push(Instruction::JumpIfZero(vrhs, false_label.clone()));
+                self.push_inst(
+                    line,
+                    format!("(&&) when rhs `{}` is also false", vrhs.to_string()),
+                    Instruction::JumpIfZero(vrhs, false_label.clone()),
+                );
 
-                self.current_body.push(Instruction::Copy {
-                    src: Value::Literal(Literal::Integer(1)),
-                    dst: dst.clone(),
-                });
-                self.current_body.push(Instruction::Jump(end_label.clone()));
+                self.push_inst(
+                    line,
+                    format!("(&&) (both true) `{}` (result) = 1", dst.to_string()),
+                    Instruction::Copy {
+                        src: Value::Literal(Literal::Integer(1)),
+                        dst: dst.clone(),
+                    },
+                );
+                self.push_inst(
+                    line,
+                    format!("(&&) (both true) jump to end"),
+                    Instruction::Jump(end_label.clone()),
+                );
 
-                self.current_body.push(Instruction::Label(false_label));
-                self.current_body.push(Instruction::Copy {
-                    src: Value::Literal(Literal::Integer(0)),
-                    dst: dst.clone(),
-                });
-                self.current_body.push(Instruction::Label(end_label));
+                self.push_inst(line, "".to_string(), Instruction::Label(false_label));
+                self.push_inst(
+                    line,
+                    format!("(&&) (false) `{}` (result) = 0", dst.to_string()),
+                    Instruction::Copy {
+                        src: Value::Literal(Literal::Integer(0)),
+                        dst: dst.clone(),
+                    },
+                );
+                self.push_inst(line, "".to_string(), Instruction::Label(end_label));
 
                 dst
             }
@@ -106,24 +159,44 @@ impl ExprRefVisitor<Value> for GenerateTacky {
                 let end_label = self.new_label("or_end");
 
                 let vlhs = self.visit_expr(lhs);
-                self.current_body
-                    .push(Instruction::JumpIfNotZero(vlhs, true_label.clone()));
+                self.push_inst(
+                    line,
+                    format!("(||) when lhs `{}` is true", vlhs.to_string()),
+                    Instruction::JumpIfNotZero(vlhs, true_label.clone()),
+                );
+
                 let vrhs = self.visit_expr(rhs);
-                self.current_body
-                    .push(Instruction::JumpIfNotZero(vrhs, true_label.clone()));
+                self.push_inst(
+                    line,
+                    format!("(||) when rhs `{}` is true", vrhs.to_string()),
+                    Instruction::JumpIfNotZero(vrhs, true_label.clone()),
+                );
 
-                self.current_body.push(Instruction::Copy {
-                    src: Value::Literal(Literal::Integer(0)),
-                    dst: dst.clone(),
-                });
-                self.current_body.push(Instruction::Jump(end_label.clone()));
+                self.push_inst(
+                    line,
+                    format!("(||) (both false) `{}` (result) = 0", dst.to_string()),
+                    Instruction::Copy {
+                        src: Value::Literal(Literal::Integer(0)),
+                        dst: dst.clone(),
+                    },
+                );
+                self.push_inst(
+                    line,
+                    format!("(||) (both false) jump to end"),
+                    Instruction::Jump(end_label.clone()),
+                );
 
-                self.current_body.push(Instruction::Label(true_label));
-                self.current_body.push(Instruction::Copy {
-                    src: Value::Literal(Literal::Integer(1)),
-                    dst: dst.clone(),
-                });
-                self.current_body.push(Instruction::Label(end_label));
+                self.push_inst(line, "".to_string(), Instruction::Label(true_label));
+
+                self.push_inst(
+                    line,
+                    format!("(||) (true) `{}` (result) = 1", dst.to_string()),
+                    Instruction::Copy {
+                        src: Value::Literal(Literal::Integer(1)),
+                        dst: dst.clone(),
+                    },
+                );
+                self.push_inst(line, "".to_string(), Instruction::Label(end_label));
 
                 dst
             }
@@ -131,8 +204,11 @@ impl ExprRefVisitor<Value> for GenerateTacky {
                 let vlhs = self.visit_expr(lhs);
                 let vrhs = self.visit_expr(rhs);
                 let dst = self.new_var();
-                self.current_body
-                    .push(Instruction::Binary(op, vlhs, vrhs, dst.clone()));
+                self.push_inst(
+                    line,
+                    format!("`{}` {} `{}`", vlhs.to_string(), op, vrhs.to_string()),
+                    Instruction::Binary(op, vlhs, vrhs, dst.clone()),
+                );
                 dst
             }
         }
@@ -143,26 +219,57 @@ impl ExprRefVisitor<Value> for GenerateTacky {
         let end_label = self.new_label("end_condexpr");
 
         let result = self.visit_expr(&expr.cond);
-        self.current_body
-            .push(Instruction::JumpIfZero(result, else_label.clone()));
+        self.push_inst(
+            expr.qmark.line,
+            format!("(c?t:e) condition is false"),
+            Instruction::JumpIfZero(result, else_label.clone()),
+        );
 
         let dst = self.new_var();
 
         let res_if = self.visit_expr(&expr.then_expr);
-        self.current_body.push(Instruction::Copy {
-            src: res_if,
-            dst: dst.clone(),
-        });
-        self.current_body.push(Instruction::Jump(end_label.clone()));
+        self.push_inst(
+            expr.qmark.line,
+            format!(
+                "(c?t:e) {} (expr_result) = {} (then_result)",
+                dst.to_string(),
+                res_if.to_string()
+            ),
+            Instruction::Copy {
+                src: res_if,
+                dst: dst.clone(),
+            },
+        );
+        self.push_inst(
+            expr.qmark.line,
+            "(c?t:e)".to_string(),
+            Instruction::Jump(end_label.clone()),
+        );
 
-        self.current_body.push(Instruction::Label(else_label));
+        self.push_inst(
+            expr.colon.line,
+            "(c?t:e) e:".to_string(),
+            Instruction::Label(else_label),
+        );
         let res_else = self.visit_expr(&expr.else_expr);
-        self.current_body.push(Instruction::Copy {
-            src: res_else,
-            dst: dst.clone(),
-        });
+        self.push_inst(
+            expr.colon.line,
+            format!(
+                "(c?t:e) {} (expr_result) = {} (else_result)",
+                dst.to_string(),
+                res_else.to_string()
+            ),
+            Instruction::Copy {
+                src: res_else,
+                dst: dst.clone(),
+            },
+        );
 
-        self.current_body.push(Instruction::Label(end_label));
+        self.push_inst(
+            expr.colon.line,
+            "(c?t:e)".to_string(),
+            Instruction::Label(end_label),
+        );
         dst
     }
 
@@ -173,62 +280,97 @@ impl ExprRefVisitor<Value> for GenerateTacky {
     fn visit_unary(&mut self, expr: &ast::Unary) -> Value {
         let ast::Unary { op, expr, postfix } = expr;
         let expr_value = self.visit_expr(expr);
+        let line = op.1.line;
         let var = self.new_var();
 
         match **op {
             ast::UnaryOp::Increment => {
                 if *postfix {
-                    self.current_body.push(Instruction::Copy {
-                        src: expr_value.clone(),
-                        dst: var.clone(),
-                    });
-                    self.current_body.push(Instruction::Binary(
-                        BinaryOp::Plus,
-                        expr_value.clone(),
-                        Value::Literal(Literal::Integer(1)),
-                        expr_value,
-                    ));
+                    self.push_inst(
+                        line,
+                        format!("(p++) copy final result of expr"),
+                        Instruction::Copy {
+                            src: expr_value.clone(),
+                            dst: var.clone(),
+                        },
+                    );
+                    self.push_inst(
+                        line,
+                        format!("(p++)  {} += 1", expr_value.to_string()),
+                        Instruction::Binary(
+                            BinaryOp::Plus,
+                            expr_value.clone(),
+                            Value::Literal(Literal::Integer(1)),
+                            expr_value,
+                        ),
+                    );
                 } else {
-                    self.current_body.push(Instruction::Binary(
-                        BinaryOp::Plus,
-                        expr_value.clone(),
-                        Value::Literal(Literal::Integer(1)),
-                        expr_value.clone(),
-                    ));
-                    self.current_body.push(Instruction::Copy {
-                        src: expr_value,
-                        dst: var.clone(),
-                    });
+                    self.push_inst(
+                        line,
+                        format!("(++) {} += 1", expr_value.to_string()),
+                        Instruction::Binary(
+                            BinaryOp::Plus,
+                            expr_value.clone(),
+                            Value::Literal(Literal::Integer(1)),
+                            expr_value.clone(),
+                        ),
+                    );
+                    self.push_inst(
+                        line,
+                        format!("(++) copy final result of expr"),
+                        Instruction::Copy {
+                            src: expr_value,
+                            dst: var.clone(),
+                        },
+                    );
                 }
             }
             ast::UnaryOp::Decrement => {
                 if *postfix {
-                    self.current_body.push(Instruction::Copy {
-                        src: expr_value.clone(),
-                        dst: var.clone(),
-                    });
-                    self.current_body.push(Instruction::Binary(
-                        BinaryOp::Minus,
-                        expr_value.clone(),
-                        Value::Literal(Literal::Integer(1)),
-                        expr_value,
-                    ));
+                    self.push_inst(
+                        line,
+                        format!("(p--) copy final result of expr"),
+                        Instruction::Copy {
+                            src: expr_value.clone(),
+                            dst: var.clone(),
+                        },
+                    );
+                    self.push_inst(
+                        line,
+                        format!("(p--)  {} -= 1", expr_value.to_string()),
+                        Instruction::Binary(
+                            BinaryOp::Minus,
+                            expr_value.clone(),
+                            Value::Literal(Literal::Integer(1)),
+                            expr_value,
+                        ),
+                    );
                 } else {
-                    self.current_body.push(Instruction::Binary(
-                        BinaryOp::Minus,
-                        expr_value.clone(),
-                        Value::Literal(Literal::Integer(1)),
-                        expr_value.clone(),
-                    ));
-                    self.current_body.push(Instruction::Copy {
-                        src: expr_value,
-                        dst: var.clone(),
-                    });
+                    self.push_inst(
+                        line,
+                        format!("(--) {} -= 1", expr_value.to_string()),
+                        Instruction::Binary(
+                            BinaryOp::Minus,
+                            expr_value.clone(),
+                            Value::Literal(Literal::Integer(1)),
+                            expr_value.clone(),
+                        ),
+                    );
+                    self.push_inst(
+                        line,
+                        format!("(--) copy final result of expr"),
+                        Instruction::Copy {
+                            src: expr_value,
+                            dst: var.clone(),
+                        },
+                    );
                 }
             }
-            _ => self
-                .current_body
-                .push(Instruction::Unary(**op, expr_value, var.clone())),
+            _ => self.push_inst(
+                line,
+                format!("(unary) {} {}", **op, expr_value.to_string()),
+                Instruction::Unary(**op, expr_value, var.clone()),
+            ),
         }
         var
     }
@@ -248,7 +390,11 @@ impl StmtRefVisitor<()> for GenerateTacky {
     }
 
     fn visit_goto(&mut self, label: &WithToken<String>) -> () {
-        self.current_body.push(Instruction::Jump((**label).clone()));
+        self.push_inst(
+            label.1.line,
+            "goto".to_string(),
+            Instruction::Jump((**label).clone()),
+        );
     }
 
     fn visit_if(&mut self, if_stmt: &ast::IfStmt) -> () {
@@ -260,31 +406,49 @@ impl StmtRefVisitor<()> for GenerateTacky {
         };
 
         let result = self.visit_expr(&if_stmt.cond);
-        self.current_body
-            .push(Instruction::JumpIfZero(result, jump_not_true.clone()));
+        self.push_inst(
+            if_stmt.cond.1.line,
+            format!("condition not true"),
+            Instruction::JumpIfZero(result, jump_not_true.clone()),
+        );
 
         self.visit_stmt(&if_stmt.then);
 
         if let Some(ref else_clause) = if_stmt.else_clause {
-            self.current_body.push(Instruction::Jump(end_label.clone()));
-            self.current_body.push(Instruction::Label(jump_not_true));
+            self.push_inst(
+                else_clause.1.line,
+                "condition true (skip else)".to_string(),
+                Instruction::Jump(end_label.clone()),
+            );
+            self.push_inst(
+                else_clause.1.line,
+                "".to_string(),
+                Instruction::Label(jump_not_true),
+            );
             self.visit_stmt(&else_clause);
         }
 
-        self.current_body.push(Instruction::Label(end_label));
+        self.push_inst(
+            if_stmt.cond.1.line,
+            "".to_string(),
+            Instruction::Label(end_label),
+        );
     }
 
     fn visit_label(&mut self, label: &ast::Label) -> () {
-        self.current_body
-            .push(Instruction::Label((*label.name).clone()));
+        self.push_inst(
+            label.name.1.line,
+            "".to_string(),
+            Instruction::Label((*label.name).clone()),
+        );
         self.visit_stmt(&label.next_stmt);
     }
 
     fn visit_null(&mut self) -> () {}
 
-    fn visit_return(&mut self, ret_value: &ast::Expr) -> () {
-        let ret_value = self.visit_expr(ret_value);
-        self.current_body.push(Instruction::Return(ret_value));
+    fn visit_return(&mut self, ret_value: &WithToken<ast::Expr>) -> () {
+        let ret = self.visit_expr(ret_value);
+        self.push_inst(ret_value.1.line, "".to_string(), Instruction::Return(ret));
     }
 }
 
@@ -305,8 +469,11 @@ impl ASTRefVisitor for GenerateTacky {
 
     fn visit_function_def(&mut self, function_def: &ast::FunctionDef) -> Self::FuncDefResult {
         self.visit_compound(&function_def.body);
-        self.current_body
-            .push(Instruction::Return(Value::Literal(Literal::Integer(0))));
+        self.push_inst(
+            function_def.name.1.line,
+            "return 0".to_string(),
+            Instruction::Return(Value::Literal(Literal::Integer(0))),
+        );
         let body = std::mem::replace(&mut self.current_body, Vec::new());
         FunctionDef {
             name: function_def.name.0.clone(),
@@ -327,7 +494,11 @@ impl ASTRefVisitor for GenerateTacky {
         if let Some(ref expr) = var_decl.init {
             let dst = self.visit_var(&var_decl.name);
             let src = self.visit_expr(expr);
-            self.current_body.push(Instruction::Copy { src, dst });
+            self.push_inst(
+                var_decl.name.1.line,
+                format!("(decl) {} = <init>", &*var_decl.name),
+                Instruction::Copy { src, dst },
+            );
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several changes to enhance the debugging capabilities and improve the handling of tokens and expressions in the parser. The most important changes include adding a new `DebugInfo` structure, modifying the `WithToken` and `WithDebugInfo` structures, and updating various parts of the parser and resolver to incorporate these changes.

### Debugging Enhancements:

* Added `DebugInfo` and `WithDebugInfo` structures to store debugging information alongside values. (`src/debug_info.rs`)
* Updated `FunctionDef` and `GenerateTacky` to use `WithDebugInfo<Instruction>` for better debugging information in `tacky.rs`. (`src/tacky.rs`) [[1]](diffhunk://#diff-80431fc27e6e28bbf208b6d06537efd75c1b6e4bbe4e6b50039e6a3aa8e94864R1) [[2]](diffhunk://#diff-80431fc27e6e28bbf208b6d06537efd75c1b6e4bbe4e6b50039e6a3aa8e94864L11-R12) [[3]](diffhunk://#diff-80431fc27e6e28bbf208b6d06537efd75c1b6e4bbe4e6b50039e6a3aa8e94864R35-R48) [[4]](diffhunk://#diff-80431fc27e6e28bbf208b6d06537efd75c1b6e4bbe4e6b50039e6a3aa8e94864R70-R152) [[5]](diffhunk://#diff-80431fc27e6e28bbf208b6d06537efd75c1b6e4bbe4e6b50039e6a3aa8e94864L109-R211) [[6]](diffhunk://#diff-80431fc27e6e28bbf208b6d06537efd75c1b6e4bbe4e6b50039e6a3aa8e94864L146-R272)

### Parser Enhancements:

* Modified `Conditional` struct to include `qmark` and `colon` tokens for better error reporting and debugging. (`src/parser/expr.rs`)
* Updated `Parser` methods to use `WithToken` for storing tokens alongside expressions and statements. (`src/parser/mod.rs`) [[1]](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49L306-R316) [[2]](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49L519-R528) [[3]](diffhunk://#diff-fc6a8d66b8cb6bd48a119a70e489cbcef82e7f551e7cf08e8e972ef4e774ef49L539-R542)
* Added `map` and `transpose` methods to `WithToken` for easier manipulation of wrapped values. (`src/parser/ast.rs`)

### Resolver Enhancements:

* Updated `Resolver` to handle `WithToken` and `WithDebugInfo` structures, ensuring that debugging information is preserved throughout the resolution process. (`src/resolver/mod.rs`) [[1]](diffhunk://#diff-8011e2789b524940bae5b965595c4bd762e81f29f35ded30f1afd12e38d6d233R78-R79) [[2]](diffhunk://#diff-8011e2789b524940bae5b965595c4bd762e81f29f35ded30f1afd12e38d6d233L133-R139) [[3]](diffhunk://#diff-8011e2789b524940bae5b965595c4bd762e81f29f35ded30f1afd12e38d6d233L153-R157)

### Pretty Printing Enhancements:

* Modified `PrettyPrint` to handle `WithToken<Expr>` for improved output formatting. (`src/parser/pretty_print_ast.rs`)

### Miscellaneous:

* Added `debug_info` module to the project. (`src/lib.rs`)
* Updated `Stmt` and `StmtRefVisitor` to use `WithToken<Expr>` for return statements and conditional expressions. (`src/parser/stmt.rs`) [[1]](diffhunk://#diff-be9592c5274e99eabeeab97e32d7bf873e5360023df6f66946a0656525eab5f8L5-R7) [[2]](diffhunk://#diff-be9592c5274e99eabeeab97e32d7bf873e5360023df6f66946a0656525eab5f8L27-R27) [[3]](diffhunk://#diff-be9592c5274e99eabeeab97e32d7bf873e5360023df6f66946a0656525eab5f8L37-R37) [[4]](diffhunk://#diff-be9592c5274e99eabeeab97e32d7bf873e5360023df6f66946a0656525eab5f8L47-R47)