### PR TITLE
Added comments in generated assembly for help in debugging

### DIFF
--- a/src/debug_info.rs
+++ b/src/debug_info.rs
@@ -1,0 +1,32 @@
+#[derive(Debug, Clone)]
+pub struct DebugInfo {
+    pub line: usize,
+    pub description: String,
+}
+
+impl DebugInfo {
+    pub fn new(line: usize, description: String) -> Self {
+        Self { line, description }
+    }
+
+    pub fn add_description(&mut self, description: String) {
+        self.description = format!("({}) {}", self.description, description);
+    }
+
+    pub fn with_more_info(mut self, description: String) -> Self {
+        self.add_description(description);
+        self
+    }
+
+    pub fn more_info(&self, description: String) -> Self {
+        let mut self_clone = self.clone();
+        self_clone.add_description(description);
+        self_clone
+    }
+}
+
+impl std::fmt::Display for DebugInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "line {} :: {}", self.line, self.description)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod asm;
+pub mod debug_info;
 pub mod lexer;
 pub mod parser;
 pub mod resolver;

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -18,6 +18,22 @@ impl<T> WithToken<T> {
     pub fn replace(&mut self, new_val: T) -> T {
         std::mem::replace(&mut self.0, new_val)
     }
+
+    pub fn map<U>(self, f: impl FnOnce(T) -> U) -> WithToken<U> {
+        WithToken(f(self.0), self.1)
+    }
+}
+
+impl<T, E> WithToken<Result<T, E>> {
+    pub fn transpose(self) -> Result<WithToken<T>, E> {
+        self.0.map(|t| WithToken(t, self.1))
+    }
+}
+
+impl<T> WithToken<Option<T>> {
+    pub fn transpose(self) -> Option<WithToken<T>> {
+        self.0.map(|t| WithToken(t, self.1))
+    }
 }
 
 impl<T> Deref for WithToken<T> {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -40,6 +40,8 @@ pub struct Conditional {
     pub cond: Box<Expr>,
     pub then_expr: Box<Expr>,
     pub else_expr: Box<Expr>,
+    pub qmark: Token,
+    pub colon: Token,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -122,6 +124,15 @@ impl Display for BinaryOp {
 pub enum Literal {
     Integer(i64),
     Float(f64),
+}
+
+impl Display for Literal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Literal::Integer(i) => write!(f, "{}", i),
+            Literal::Float(fl) => write!(f, "{}", fl),
+        }
+    }
 }
 
 pub trait ExprRefVisitor<R> {

--- a/src/parser/pretty_print_ast.rs
+++ b/src/parser/pretty_print_ast.rs
@@ -204,7 +204,7 @@ impl StmtRefVisitor<String> for PrettyPrint {
         format!("{}{}", Self::INDENT.repeat(self.indent), "NULL".red())
     }
 
-    fn visit_return(&mut self, ret_value: &Expr) -> String {
+    fn visit_return(&mut self, ret_value: &WithToken<Expr>) -> String {
         self.indent += 1;
         let ret_str = format!(
             "{}{} \x0b{}",

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -2,9 +2,9 @@ use super::{expr::Expr, BlockItem, WithToken};
 
 #[derive(Debug)]
 pub struct IfStmt {
-    pub cond: Expr,
+    pub cond: WithToken<Expr>,
     pub then: Box<Stmt>,
-    pub else_clause: Option<Box<Stmt>>,
+    pub else_clause: Option<Box<WithToken<Stmt>>>,
 }
 
 #[derive(Debug)]
@@ -24,7 +24,7 @@ pub enum Stmt {
     If(IfStmt),
     Label(Label),
     Null,
-    Return { ret_value: Expr },
+    Return { ret_value: WithToken<Expr> },
 }
 
 pub trait StmtRefVisitor<R> {
@@ -34,7 +34,7 @@ pub trait StmtRefVisitor<R> {
     fn visit_if(&mut self, if_stmt: &IfStmt) -> R;
     fn visit_label(&mut self, label: &Label) -> R;
     fn visit_null(&mut self) -> R;
-    fn visit_return(&mut self, ret_value: &Expr) -> R;
+    fn visit_return(&mut self, ret_value: &WithToken<Expr>) -> R;
 }
 
 pub trait StmtVisitor<R> {
@@ -44,5 +44,5 @@ pub trait StmtVisitor<R> {
     fn visit_if(&mut self, if_stmt: IfStmt) -> R;
     fn visit_label(&mut self, label: Label) -> R;
     fn visit_null(&mut self) -> R;
-    fn visit_return(&mut self, ret_value: Expr) -> R;
+    fn visit_return(&mut self, ret_value: WithToken<Expr>) -> R;
 }


### PR DESCRIPTION
This pull request includes several changes to the `src/asm.rs` file to add debug information to various instructions and refactor some functions. Additionally, new utility functions and structs are introduced in other files to support these changes.

### Debug Information Enhancements:
* Added `DebugInfo` struct to `src/debug_info.rs` to encapsulate debug information, including line numbers and descriptions.
* Modified various `Instruction` variants to include a `DebugInfo` field, ensuring debug information is carried through different instruction types in `src/asm.rs`.
* Updated instruction handling functions to propagate `DebugInfo` through the instruction generation and transformation process in `src/asm.rs`. [[1]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649L112-R119) [[2]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649R128-R148) [[3]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649R157-R172) [[4]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649R182-R216) [[5]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649L219-R249) [[6]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649R492-R511) [[7]](diffhunk://#diff-bac452d968c2be037700e39f0aa27cff682f20cea90185644135d177094d1649L446-R565)

### Refactoring and Utility Functions:
* Renamed `indent` function to `indent_str` and added a new `indent` function that works with `String` slices in `src/asm.rs`.
* Introduced `WithToken` utility methods `map`, `transpose` for `Result` and `Option` types in `src/parser/ast.rs`.
* Added `qmark` and `colon` tokens to the `Conditional` struct in `src/parser/expr.rs` to support better token management.

### Module Imports:
* Added import for `debug_info` module in `src/lib.rs` to make the new `DebugInfo` struct available throughout the project.
* Imported `DebugInfo` in `src/asm.rs` to utilize the new debug information struct in instruction definitions and transformations.