### PR TITLE
Blocks/functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ paste = "1.0.15"
 thiserror = "1.0.63"
 
 [features]
-default = ["resolve", "asm_gen"]
+default = ["resolve"] # , "asm_gen"]
 resolve = []
 asm_gen = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ paste = "1.0.15"
 thiserror = "1.0.63"
 
 [features]
-default = ["resolve"] # , "asm_gen"]
+default = ["resolve", "tacky_gen", "asm_gen"]
 resolve = []
 asm_gen = []
+tacky_gen = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,10 @@ use parser::{
 };
 use std::fs;
 
-#[cfg(feature = "asm_gen")]
+#[cfg(feature = "resolve")]
+use type_checker::TypeChecker;
+
+#[cfg(feature = "tacky_gen")]
 use tacky::GenerateTacky;
 
 pub mod debug_info;
@@ -26,11 +29,11 @@ pub mod resolver;
 use resolver::Resolver;
 #[cfg(feature = "resolve")]
 pub mod type_checker;
-#[cfg(feature = "resolve")]
-use type_checker::TypeChecker;
+
 #[cfg(feature = "asm_gen")]
 pub mod asm;
-#[cfg(feature = "asm_gen")]
+
+#[cfg(feature = "tacky_gen")]
 pub mod tacky;
 
 #[cfg_attr(not(feature = "asm_gen"), allow(unused_variables))]
@@ -49,20 +52,28 @@ pub fn compile(input: &str, debug: bool) -> anyhow::Result<String> {
         resolved_prog
     };
 
+    #[cfg(feature = "tacky_gen")]
+    let tacky_prog = {
+        let tacky_prog = GenerateTacky::new().visit_program(&program);
+        if debug {
+            println!("Tacky: {tacky_prog:#?}");
+        }
+        tacky_prog
+    };
+
     #[cfg(feature = "asm_gen")]
     {
-        let tacky_prog = GenerateTacky::new().visit_program(&program);
         let asm = asm::Program::from(&tacky_prog);
         let asm_string = asm.to_asm_string();
 
         if debug {
-            println!("Tacky: {tacky_prog:#?}");
             println!("ASM: {asm:#?}");
             println!("ASM:\n{}", asm_string);
         }
 
         return Ok(asm_string);
     }
+
     Ok(PrettyPrint::new().visit_program(&program))
 }
 
@@ -74,12 +85,18 @@ pub fn assemble(
     to_object: bool,
     keep_asm: bool,
     debug: bool,
-) -> std::io::Result<ExitStatus> {
+) -> std::io::Result<(ExitStatus, String)> {
     #[cfg(feature = "asm_gen")]
     {
         let asm_file_path = file.with_extension("s");
         let out_file = if let Some(out) = output {
             out.clone()
+        } else if to_object {
+            asm_file_path
+                .with_extension("o")
+                .to_str()
+                .unwrap()
+                .to_string()
         } else {
             asm_file_path
                 .with_extension("")
@@ -101,6 +118,10 @@ pub fn assemble(
             .arg("-g")
             .args(["-o", &out_file]);
 
+        if to_object {
+            command.arg("-c");
+        }
+
         if debug {
             println!("Assembling with command {:?}", command)
         };
@@ -115,11 +136,11 @@ pub fn assemble(
             eprintln!("Failed to compile");
         }
 
-        Ok(exit_status)
+        Ok((exit_status, out_file))
     }
 
     #[cfg(not(feature = "asm_gen"))]
     {
-        Ok(ExitStatus::from_raw(0))
+        Ok((ExitStatus::from_raw(0), out_file))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,64 +4,82 @@ use ccrust::lexer::LexerError;
 use ccrust::parser::ParseError;
 #[cfg(feature = "resolve")]
 use ccrust::resolver::ResolveError;
+use ccrust::type_checker::TypeCheckerError;
 use clap::Parser;
 use colored::Colorize;
 use std::fs;
 use std::path::Path;
 
 #[derive(Parser)]
+#[command(name = "ccrust")]
 #[command(version, about, long_about = None)]
 struct Cli {
     /// Path of input C file
-    file: String,
+    files: Vec<String>,
 
     /// Specify path of output executable
     #[arg(long, short)]
     output: Option<String>,
+
+    /// Compile to object file
+    #[arg(short)]
+    compile_to_object: bool,
 }
 
 fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
 
-    let path = Path::new(&cli.file);
-    let text = fs::read_to_string(path)?;
+    for file in cli.files.iter() {
+        let path = Path::new(file);
+        let text = fs::read_to_string(path)?;
 
-    let compile_result = compile(&text, true);
+        let compile_result = compile(&text, true);
 
-    let Ok(asm_string) = compile_result else {
-        let err = compile_result.unwrap_err();
-        let err_msg = err.to_string();
+        let Ok(asm_string) = compile_result else {
+            let err = compile_result.unwrap_err();
+            let err_msg = err.to_string();
 
-        let res = err
-            .downcast::<LexerError>()
-            .map(|le| le.token)
-            .or_else(|err| err.downcast::<ParseError>().map(|pe| pe.token));
+            let res = err
+                .downcast::<LexerError>()
+                .map(|le| le.token)
+                .or_else(|err| err.downcast::<ParseError>().map(|pe| pe.token));
 
-        #[cfg(feature = "resolve")]
-        let res = res.or_else(|err| err.downcast::<ResolveError>().map(|re| re.token));
+            #[cfg(feature = "resolve")]
+            let res = {
+                res.or_else(|err| err.downcast::<ResolveError>().map(|re| re.token))
+                    .or_else(|err| err.downcast::<TypeCheckerError>().map(|te| te.token))
+            };
 
-        res.map(|token| {
-            eprintln!(
-                "{}",
-                format!(
-                    "Error {}:{} (at ({:?}):: {}",
-                    token.line,
-                    token.span.0,
-                    &text[token.span.0..token.span.1],
-                    err_msg
-                )
-                .red()
-            );
-        })
-        .unwrap();
+            res.map(|token| {
+                eprintln!(
+                    "{}",
+                    format!(
+                        "Error {}:{} (at ({:?}):: {}",
+                        token.line,
+                        token.span.0,
+                        &text[token.span.0..token.span.1],
+                        err_msg
+                    )
+                    .red()
+                );
+            })
+            .unwrap();
 
-        std::process::exit(-1);
-    };
+            std::process::exit(-1);
+        };
 
-    #[cfg(not(feature = "asm_gen"))]
-    println!("{}", asm_string);
+        #[cfg(not(feature = "asm_gen"))]
+        println!("{}\n{}:\n{}\n", "-".repeat(20), file, asm_string);
 
-    let _status = assemble(&path, &asm_string, &cli.output, true, true)?;
+        let _status = assemble(
+            &path,
+            &asm_string,
+            &cli.output,
+            cli.compile_to_object,
+            true,
+            true,
+        )?;
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,10 +30,11 @@ struct Cli {
 fn main() -> std::io::Result<()> {
     let cli = Cli::parse();
 
-    let (pseudo_compile_to_object, pseudo_output) = if cli.files.len() > 1 {
+    // When multiple files are provided, force compilation to object files and ignore the output option
+    let (force_object_compilation, adjusted_output) = if cli.files.len() > 1 {
         (true, None)
     } else {
-        (cli.compile_to_object, cli.output.clone())
+        (cli.compile_to_object, cli.output.clone()) // Use provided options for a single file
     };
 
     let mut out_files = Vec::new();
@@ -82,8 +83,8 @@ fn main() -> std::io::Result<()> {
         let (_status, out_file) = assemble(
             &path,
             &asm_string,
-            &pseudo_output,
-            pseudo_compile_to_object,
+            &adjusted_output,
+            force_object_compilation,
             true,
             true,
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,7 +91,7 @@ fn main() -> std::io::Result<()> {
         out_files.push(out_file);
     }
 
-    if cli.files.len() > 0 && !cli.compile_to_object {
+    if cli.files.len() > 1 && !cli.compile_to_object {
         let mut command = Command::new("gcc");
 
         command

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::lexer::token::Token;
 
-use super::ast::{Identifier, WithToken};
+use super::ast::WithToken;
 
 #[derive(Debug, Clone)]
 pub enum Expr {

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use crate::lexer::token::Token;
 
-use super::ast::WithToken;
+use super::ast::{Identifier, WithToken};
 
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -10,6 +10,7 @@ pub enum Expr {
     Binary(Binary),
     Comma(Comma),
     Conditional(Conditional),
+    FunctionCall(FunctionCall),
     Literal(WithToken<Literal>),
     Unary(Unary),
     Var(WithToken<String>),
@@ -46,6 +47,12 @@ pub struct Conditional {
     pub else_expr: Box<Expr>,
     pub qmark: Token,
     pub colon: Token,
+}
+
+#[derive(Debug, Clone)]
+pub struct FunctionCall {
+    pub name: Box<Expr>,
+    pub args: Vec<WithToken<Expr>>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -149,6 +156,7 @@ pub trait ExprRefVisitor<R> {
     fn visit_binary(&mut self, expr: &Binary) -> R;
     fn visit_comma(&mut self, expr: &Comma) -> R;
     fn visit_conditional(&mut self, expr: &Conditional) -> R;
+    fn visit_function_call(&mut self, call: &FunctionCall) -> R;
     fn visit_literal(&mut self, literal: &WithToken<Literal>) -> R;
     fn visit_unary(&mut self, expr: &Unary) -> R;
     fn visit_var(&mut self, name: &WithToken<String>) -> R;
@@ -159,6 +167,7 @@ pub trait ExprVisitor<R> {
     fn visit_binary(&mut self, expr: Binary) -> R;
     fn visit_comma(&mut self, expr: Comma) -> R;
     fn visit_conditional(&mut self, expr: Conditional) -> R;
+    fn visit_function_call(&mut self, call: FunctionCall) -> R;
     fn visit_literal(&mut self, literal: WithToken<Literal>) -> R;
     fn visit_unary(&mut self, expr: Unary) -> R;
     fn visit_var(&mut self, name: WithToken<String>) -> R;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -634,7 +634,7 @@ impl<'a> Parser<'a> {
             Some(TokenType::KInt) => {
                 let decl = self.declaration()?;
                 let (token, decl_type) = match decl {
-                    BlockItem::FunctionDecl(func_decl) => (func_decl.name.1, "functiom"),
+                    BlockItem::FunctionDecl(func_decl) => (func_decl.name.1, "function"),
                     BlockItem::VarDecl(mut var_decl) => {
                         (var_decl.pop().unwrap().name.1, "variable")
                     }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -1,7 +1,8 @@
 mod scoped_var_map;
 
 use crate::lexer::token::Token;
-use crate::parser::ast::*;
+use crate::parser::ast::{self, *};
+use crate::type_checker::r#type::Type;
 use scoped_var_map::ScopedVarMap;
 use thiserror::Error;
 
@@ -24,15 +25,34 @@ pub enum ResolverErrorType {
     #[error("Duplicate variable in scope (previous declaration on {prev_token:?}")]
     DuplicateVariable { prev_token: Token },
 
-    #[error("Undeclared variable")]
-    UndeclaredVariable,
-
     #[error("Invalid lvalue for assignment")]
     InvalidLValue,
+
+    #[error("symbol redeclared as different kind of value (previously declared {prev_token:?} of kind `{prev_kind}`, now declared as `{new_kind}`)")]
+    RedeclaredAsDifferentKind {
+        prev_token: Token,
+        prev_kind: &'static str,
+        new_kind: &'static str,
+    },
+
+    #[error("Undeclared variable")]
+    UndeclaredVariable,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Linkage {
+    External,
+    Internal,
+    None,
+}
+
+#[derive(Debug)]
+pub struct MapEntry {
+    pub name: WithToken<String>,
+    pub linkage: Linkage,
 }
 
 pub type ScopeDepth = i32;
-pub type MapEntry = WithToken<String>;
 
 pub struct Resolver {
     scope: ScopedVarMap,
@@ -125,6 +145,17 @@ impl ExprVisitor<ResolveResult<Expr>> for Resolver {
         }))
     }
 
+    fn visit_function_call(&mut self, call: FunctionCall) -> ResolveResult<Expr> {
+        Ok(Expr::FunctionCall(FunctionCall {
+            name: call.name,
+            args: call
+                .args
+                .into_iter()
+                .map(|arg| arg.map(|e| self.visit_expr(e)).transpose())
+                .collect::<Result<Vec<_>, _>>()?,
+        }))
+    }
+
     fn visit_literal(&mut self, lit: WithToken<Literal>) -> ResolveResult<Expr> {
         Ok(Expr::Literal(lit))
     }
@@ -138,8 +169,8 @@ impl ExprVisitor<ResolveResult<Expr>> for Resolver {
     }
 
     fn visit_var(&mut self, name: WithToken<String>) -> ResolveResult<Expr> {
-        if let Some(val) = self.scope.lookup(&**name) {
-            Ok(Expr::Var(val.clone()))
+        if let Some(entry) = self.scope.lookup(&**name) {
+            Ok(Expr::Var(entry.name.clone()))
         } else {
             Err(ResolveError {
                 token: name.1,
@@ -344,7 +375,7 @@ impl StmtVisitor<ResolveResult<Stmt>> for Resolver {
 impl ASTVisitor for Resolver {
     type BlockItemResult = ResolveResult<BlockItem>;
     type ExprResult = ResolveResult<Expr>;
-    type FuncDefResult = ResolveResult<FunctionDef>;
+    type FuncDeclResult = ResolveResult<FunctionDecl>;
     type ProgramResult = ResolveResult<Program>;
     type StmtResult = ResolveResult<Stmt>;
     type VarDeclResult = ResolveResult<VarDecl>;
@@ -358,23 +389,77 @@ impl ASTVisitor for Resolver {
                     .map(|decl| self.visit_var_decl(decl))
                     .collect::<Result<Vec<_>, _>>()?,
             ),
+            BlockItem::FunctionDecl(func_decl) => {
+                BlockItem::FunctionDecl(self.visit_function_decl(func_decl)?)
+            }
         })
     }
 
-    fn visit_function_def(&mut self, function_def: FunctionDef) -> Self::FuncDefResult {
-        let Stmt::Compound(body) = self.visit_compound(function_def.body)? else {
-            unreachable!();
-        };
-        Ok(FunctionDef {
-            name: function_def.name,
+    fn visit_function_decl(&mut self, function_decl: FunctionDecl) -> Self::FuncDeclResult {
+        if let Some(prev_entry) = self.scope.lookup(&*function_decl.name.0) {
+            if prev_entry.linkage == Linkage::None {
+                return Err(ResolveError {
+                    token: function_decl.name.1,
+                    error_type: ResolverErrorType::RedeclaredAsDifferentKind {
+                        prev_token: prev_entry.name.1.clone(),
+                        prev_kind: "variable",
+                        new_kind: "function",
+                    },
+                });
+            }
+        }
+
+        self.scope.insert(
+            function_decl.name.0.clone(),
+            MapEntry {
+                name: function_decl.name.clone(),
+                linkage: Linkage::Internal,
+            },
+        );
+
+        self.begin_scope();
+        let params = function_decl
+            .params
+            .into_iter()
+            .map(|p| {
+                self.visit_var_decl(ast::VarDecl {
+                    name: p,
+                    init: None,
+                    ty: Type::Int,
+                })
+                .map(|decl| decl.name)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let body = function_decl
+            .body
+            .map(|stmt| {
+                self.visit_compound(CompoundStmt {
+                    introduce_scope: false,
+                    ..stmt
+                })
+            })
+            .transpose()?;
+        let body = body.map(|stmt| {
+            let Stmt::Compound(cs) = stmt else {
+                unreachable!()
+            };
+            cs
+        });
+
+        self.end_scope();
+        Ok(FunctionDecl {
+            name: function_decl.name,
+            params,
             body,
         })
     }
+
     fn visit_program(&mut self, program: Program) -> Self::ProgramResult {
         let body = program
             .0
             .into_iter()
-            .map(|f| self.visit_function_def(f))
+            .map(|f| self.visit_function_decl(f))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Program(body))
     }
@@ -385,7 +470,21 @@ impl ASTVisitor for Resolver {
             self.scope, self.scope_depth
         );
         match self.scope.get(&*var_decl.name) {
-            Some(WithToken(_, tok)) => {
+            Some(MapEntry {
+                name: WithToken(_, tok),
+                linkage,
+            }) => {
+                if *linkage != Linkage::None {
+                    return Err(ResolveError {
+                        token: tok.clone(),
+                        error_type: ResolverErrorType::RedeclaredAsDifferentKind {
+                            prev_token: tok.clone(),
+                            prev_kind: "function",
+                            new_kind: "variable",
+                        },
+                    });
+                }
+
                 let prev_token = tok.clone();
                 let token = var_decl.name.1;
                 Err(ResolveError {
@@ -397,7 +496,13 @@ impl ASTVisitor for Resolver {
                 let old_name = var_decl.name;
                 let new_name = WithToken(self.make_unique(&old_name.0), old_name.1);
 
-                self.scope.insert(old_name.0, new_name.clone());
+                self.scope.insert(
+                    old_name.0,
+                    MapEntry {
+                        name: new_name.clone(),
+                        linkage: Linkage::None,
+                    },
+                );
 
                 let new_init = var_decl
                     .init
@@ -406,6 +511,7 @@ impl ASTVisitor for Resolver {
                 Ok(VarDecl {
                     name: new_name,
                     init: new_init,
+                    ty: var_decl.ty,
                 })
             }
         }

--- a/src/resolver/scoped_var_map.rs
+++ b/src/resolver/scoped_var_map.rs
@@ -11,7 +11,7 @@ pub struct ScopedVarMap {
 impl ScopedVarMap {
     pub fn new() -> ScopedVarMap {
         ScopedVarMap {
-            scope_stack: Vec::new(),
+            scope_stack: vec![VarMap::new()],
         }
     }
 

--- a/src/tacky.rs
+++ b/src/tacky.rs
@@ -3,8 +3,8 @@ use std::fmt::Display;
 use crate::{
     debug_info::DebugInfo,
     parser::ast::{
-        self, ASTRefVisitor, BinaryOp, BlockItem, BreakStmt, ExprRefVisitor, ForStmtInitializer,
-        Integral, Literal, StmtRefVisitor, WithToken,
+        self, ASTRefVisitor, BinaryOp, BlockItem, BreakStmt, Expr, ExprRefVisitor,
+        ForStmtInitializer, Integral, Literal, StmtRefVisitor, WithToken,
     },
 };
 
@@ -42,6 +42,7 @@ pub struct Program(pub Vec<FunctionDef>);
 #[derive(Debug)]
 pub struct FunctionDef {
     pub name: String,
+    pub params: Vec<String>,
     pub body: Vec<Instruction>,
 }
 
@@ -55,6 +56,12 @@ pub enum Instruction {
     Copy {
         src: Value,
         dst: Value,
+        debug_info: DebugInfo,
+    },
+    FunctionCall {
+        name: Value,
+        args: Vec<Value>,
+        dest: Value,
         debug_info: DebugInfo,
     },
     Jump(Target, DebugInfo),
@@ -269,6 +276,23 @@ impl ExprRefVisitor<Value> for GenerateTacky {
         }
 
         dst
+    }
+
+    fn visit_function_call(&mut self, call: &ast::FunctionCall) -> Value {
+        let args: Vec<Value> = call.args.iter().map(|arg| self.visit_expr(&arg)).collect();
+        let dest = self.new_var();
+        let WithToken(name, name_tok) = match *call.name {
+            Expr::Var(ref name) => name.clone(),
+            _ => unreachable!(),
+        };
+        let debug_info = DebugInfo::new(name_tok.line, format!("call `{name}`"));
+        self.current_body.push(Instruction::FunctionCall {
+            name: Value::Var(name),
+            args,
+            dest: dest.clone(),
+            debug_info,
+        });
+        dest
     }
 
     fn visit_literal(&mut self, literal: &ast::WithToken<Literal>) -> Value {
@@ -630,7 +654,7 @@ impl StmtRefVisitor<()> for GenerateTacky {
 impl ASTRefVisitor for GenerateTacky {
     type BlockItemResult = ();
     type ExprResult = Value;
-    type FuncDefResult = FunctionDef;
+    type FuncDeclResult = Option<FunctionDef>;
     type ProgramResult = Program;
     type StmtResult = ();
     type VarDeclResult = ();
@@ -639,25 +663,31 @@ impl ASTRefVisitor for GenerateTacky {
         match block_item {
             BlockItem::Stmt(stmt) => self.visit_stmt(stmt),
             BlockItem::VarDecl(decls) => decls.iter().for_each(|decl| self.visit_var_decl(decl)),
+            BlockItem::FunctionDecl(_) => {}
         };
     }
 
-    fn visit_function_def(&mut self, function_def: &ast::FunctionDef) -> Self::FuncDefResult {
-        self.visit_compound(&function_def.body);
-        // self.current_body
-        //     .push(Instruction::Return(Value::Literal(Literal::Integral(Integral::Integer(0)))));
-        let body = std::mem::replace(&mut self.current_body, Vec::new());
-        FunctionDef {
-            name: function_def.name.0.clone(),
-            body,
-        }
+    fn visit_function_decl(&mut self, function_def: &ast::FunctionDecl) -> Self::FuncDeclResult {
+        function_def.body.as_ref().map(|body| {
+            self.visit_compound(body);
+            let body = std::mem::replace(&mut self.current_body, Vec::new());
+            FunctionDef {
+                name: function_def.name.0.clone(),
+                params: function_def
+                    .params
+                    .iter()
+                    .map(|param| param.0.clone())
+                    .collect(),
+                body,
+            }
+        })
     }
 
     fn visit_program(&mut self, program: &ast::Program) -> Self::ProgramResult {
         let funs = program
             .0
             .iter()
-            .map(|f| self.visit_function_def(f))
+            .filter_map(|f| self.visit_function_decl(f))
             .collect();
         Program(funs)
     }

--- a/src/tacky.rs
+++ b/src/tacky.rs
@@ -283,7 +283,10 @@ impl ExprRefVisitor<Value> for GenerateTacky {
         let dest = self.new_var();
         let WithToken(name, name_tok) = match *call.name {
             Expr::Var(ref name) => name.clone(),
-            _ => unreachable!(),
+            _ => unreachable!(
+                "Expected Expr::Var for function name, but found: {:?}",
+                call.name
+            ),
         };
         let debug_info = DebugInfo::new(name_tok.line, format!("call `{name}`"));
         self.current_body.push(Instruction::FunctionCall {

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -461,17 +461,22 @@ impl ASTRefVisitor for TypeChecker {
     }
 
     fn visit_var_decl(&mut self, var_decl: &VarDecl) -> Self::VarDeclResult {
-        let ty = self.visit_expr(var_decl.init.as_ref().unwrap())?;
-        if ty != var_decl.ty {
-            Err(TypeCheckerError {
-                token: var_decl.name.1.clone(),
-                kind: TypeCheckerErrorKind::TypeMismatch {
-                    expected: var_decl.ty.clone(),
-                    got: ty,
-                },
-            })
+        if let Some(ref init) = var_decl.init {
+            let ty = self.visit_expr(init)?;
+            if ty != var_decl.ty {
+                Err(TypeCheckerError {
+                    token: var_decl.name.1.clone(),
+                    kind: TypeCheckerErrorKind::TypeMismatch {
+                        expected: var_decl.ty.clone(),
+                        got: ty,
+                    },
+                })
+            } else {
+                self.add_symbol(var_decl.name.clone(), ty, true);
+                Ok(())
+            }
         } else {
-            self.add_symbol(var_decl.name.clone(), ty, true);
+            self.add_symbol(var_decl.name.clone(), var_decl.ty.clone(), false);
             Ok(())
         }
     }

--- a/src/type_checker/mod.rs
+++ b/src/type_checker/mod.rs
@@ -1,0 +1,417 @@
+use std::collections::HashMap;
+
+use thiserror::Error;
+
+use crate::{
+    lexer::token::Token,
+    parser::ast::*,
+    parser::ast::{ASTRefVisitor, ExprRefVisitor},
+};
+
+pub mod r#type;
+use r#type::Type;
+
+pub type SymbolTable = HashMap<String, Type>;
+
+#[derive(Debug, Error)]
+#[error("Type error at {token:?}: {kind}")]
+pub struct TypeCheckerError {
+    pub token: Token,
+    #[source]
+    pub kind: TypeCheckerErrorKind,
+}
+
+#[derive(Debug, Error)]
+pub enum TypeCheckerErrorKind {
+    #[error("type mismatch: expected `{expected}`, got `{got}`")]
+    TypeMismatch { expected: Type, got: Type },
+
+    #[error("value of type {0} cannot be used as an lvalue")]
+    TypeCannotBeLValue(Type),
+}
+
+pub struct TypeChecker {
+    symbol_table: SymbolTable,
+}
+
+pub type TypeCheckerResult<T> = Result<T, TypeCheckerError>;
+
+impl TypeChecker {
+    pub fn new() -> Self {
+        Self {
+            symbol_table: SymbolTable::new(),
+        }
+    }
+
+    pub fn add_symbol(&mut self, name: String, ty: Type) {
+        self.symbol_table.insert(name, ty);
+    }
+
+    pub fn get_symbol(&self, name: &str) -> Option<&Type> {
+        self.symbol_table.get(name)
+    }
+}
+
+impl ExprRefVisitor<TypeCheckerResult<Type>> for TypeChecker {
+    fn visit_assign(&mut self, assign: &Assign) -> TypeCheckerResult<Type> {
+        let Expr::Var(ref name) = *assign.lhs else {
+            unreachable!()
+        };
+
+        let rhs_ty = self.visit_expr(&assign.rhs)?;
+
+        if let Some(lhs_ty) = self.get_symbol(name) {
+            match lhs_ty {
+                Type::Function { .. } => Err(TypeCheckerError {
+                    token: name.1.clone(),
+                    kind: TypeCheckerErrorKind::TypeCannotBeLValue(lhs_ty.clone()),
+                }),
+                ty if *ty != rhs_ty => Err(TypeCheckerError {
+                    token: name.1.clone(),
+                    kind: TypeCheckerErrorKind::TypeMismatch {
+                        expected: lhs_ty.clone(),
+                        got: rhs_ty,
+                    },
+                }),
+                _ => Ok(rhs_ty),
+            }
+        } else {
+            self.add_symbol(name.0.clone(), rhs_ty.clone());
+            Ok(rhs_ty)
+        }
+    }
+
+    fn visit_binary(&mut self, expr: &Binary) -> TypeCheckerResult<Type> {
+        let lhs_ty = self.visit_expr(&expr.lhs)?;
+        let rhs_ty = self.visit_expr(&expr.rhs)?;
+
+        if lhs_ty != rhs_ty {
+            return Err(TypeCheckerError {
+                token: expr.op.1.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: lhs_ty,
+                    got: rhs_ty,
+                },
+            });
+        }
+        Ok(Type::Int)
+    }
+
+    fn visit_comma(&mut self, expr: &Comma) -> TypeCheckerResult<Type> {
+        let _ = self.visit_expr(&expr.0)?;
+        self.visit_expr(&expr.1)
+    }
+
+    fn visit_conditional(&mut self, expr: &Conditional) -> TypeCheckerResult<Type> {
+        let cond_ty = self.visit_expr(&expr.cond)?;
+        let then_ty = self.visit_expr(&expr.then_expr)?;
+        let else_ty = self.visit_expr(&expr.else_expr)?;
+
+        if cond_ty != Type::Int {
+            return Err(TypeCheckerError {
+                token: expr.qmark.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: Type::Int,
+                    got: cond_ty,
+                },
+            });
+        }
+
+        if then_ty != else_ty {
+            return Err(TypeCheckerError {
+                token: expr.colon.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: then_ty,
+                    got: else_ty,
+                },
+            });
+        }
+
+        Ok(then_ty)
+    }
+
+    fn visit_function_call(&mut self, call: &FunctionCall) -> TypeCheckerResult<Type> {
+        let func_ty = self.visit_expr(&call.name)?;
+        let name = match &*call.name {
+            Expr::Var(name) => name,
+            _ => unreachable!(),
+        };
+
+        if let Type::Function { ref params } = func_ty {
+            if params.len() != call.args.len() {
+                return Err(TypeCheckerError {
+                    token: name.1.clone(),
+                    kind: TypeCheckerErrorKind::TypeMismatch {
+                        expected: func_ty,
+                        got: Type::Function {
+                            params: call.args.iter().map(|_| Type::Int).collect(),
+                        },
+                    },
+                });
+            }
+
+            for (param, arg) in params.iter().zip(call.args.iter()) {
+                let arg_ty = self.visit_expr(arg)?;
+                if *param != arg_ty {
+                    return Err(TypeCheckerError {
+                        token: arg.1.clone(),
+                        kind: TypeCheckerErrorKind::TypeMismatch {
+                            expected: param.clone(),
+                            got: arg_ty,
+                        },
+                    });
+                }
+            }
+
+            Ok(Type::Int)
+        } else {
+            Err(TypeCheckerError {
+                token: name.1.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: Type::Function {
+                        params: call.args.iter().map(|_| Type::Int).collect(),
+                    },
+                    got: func_ty,
+                },
+            })
+        }
+    }
+
+    fn visit_literal(&mut self, literal: &WithToken<Literal>) -> TypeCheckerResult<Type> {
+        match **literal {
+            Literal::Integral(_) => Ok(Type::Int),
+            Literal::Float(_) => todo!(),
+        }
+    }
+
+    fn visit_unary(&mut self, expr: &Unary) -> TypeCheckerResult<Type> {
+        let ty = self.visit_expr(&expr.expr)?;
+        if let Type::Function { .. } = ty {
+            Err(TypeCheckerError {
+                token: expr.op.1.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: Type::Int,
+                    got: ty,
+                },
+            })
+        } else {
+            Ok(Type::Int)
+        }
+    }
+
+    fn visit_var(&mut self, name: &WithToken<String>) -> TypeCheckerResult<Type> {
+        if let Some(ty) = self.get_symbol(&name.0) {
+            Ok(ty.clone())
+        } else {
+            unreachable!("variable must be resolved")
+        }
+    }
+}
+
+impl StmtRefVisitor<TypeCheckerResult<()>> for TypeChecker {
+    fn visit_break(&mut self, _: &BreakStmt) -> TypeCheckerResult<()> {
+        Ok(())
+    }
+
+    fn visit_compound(&mut self, compound_stmt: &CompoundStmt) -> TypeCheckerResult<()> {
+        for block_item in &compound_stmt.block.0 {
+            self.visit_block_item(block_item)?;
+        }
+        Ok(())
+    }
+
+    fn visit_continue(&mut self, _: &WithToken<i32>) -> TypeCheckerResult<()> {
+        Ok(())
+    }
+
+    fn visit_expression(&mut self, expr: &Expr) -> TypeCheckerResult<()> {
+        self.visit_expr(expr)?;
+        Ok(())
+    }
+
+    fn visit_for(&mut self, for_stmt: &ForStmt) -> TypeCheckerResult<()> {
+        match &*for_stmt.initializer {
+            Some(ref init) => match init {
+                ForStmtInitializer::Expr(e) => {
+                    self.visit_expr(e)?;
+                }
+                ForStmtInitializer::VarDecl(decls) => {
+                    decls
+                        .iter()
+                        .map(|d| self.visit_var_decl(d))
+                        .collect::<Result<Vec<_>, _>>()?;
+                }
+            },
+            None => {}
+        };
+
+        (*for_stmt.condition)
+            .as_ref()
+            .map(|c| self.visit_expr(c))
+            .transpose()?
+            .map(|c| {
+                if c != Type::Int {
+                    Err(TypeCheckerError {
+                        token: for_stmt.condition.1.clone(),
+                        kind: TypeCheckerErrorKind::TypeMismatch {
+                            expected: Type::Int,
+                            got: c,
+                        },
+                    })
+                } else {
+                    Ok(())
+                }
+            })
+            .transpose()?;
+
+        (*for_stmt.step)
+            .as_ref()
+            .map(|s| self.visit_expr(&s))
+            .transpose()?;
+
+        self.visit_stmt(&for_stmt.body)?;
+        Ok(())
+    }
+
+    fn visit_goto(&mut self, _: &WithToken<String>) -> TypeCheckerResult<()> {
+        Ok(())
+    }
+
+    fn visit_if(&mut self, if_stmt: &IfStmt) -> TypeCheckerResult<()> {
+        let cond_ty = self.visit_expr(&if_stmt.cond)?;
+        if cond_ty != Type::Int {
+            return Err(TypeCheckerError {
+                token: if_stmt.cond.1.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: Type::Int,
+                    got: cond_ty,
+                },
+            });
+        }
+
+        self.visit_stmt(&if_stmt.then)?;
+        if let Some(ref else_branch) = if_stmt.else_clause {
+            self.visit_stmt(else_branch)?;
+        }
+        Ok(())
+    }
+
+    fn visit_label(&mut self, label: &Label) -> TypeCheckerResult<()> {
+        self.visit_stmt(&label.next_stmt)
+    }
+
+    fn visit_null(&mut self) -> TypeCheckerResult<()> {
+        Ok(())
+    }
+
+    fn visit_return(&mut self, ret_value: &WithToken<Expr>) -> TypeCheckerResult<()> {
+        let ty = self.visit_expr(&ret_value.0)?;
+        if ty != Type::Int {
+            return Err(TypeCheckerError {
+                token: ret_value.1.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: Type::Int,
+                    got: ty,
+                },
+            });
+        }
+        Ok(())
+    }
+
+    fn visit_switch(&mut self, switch_stmt: &SwitchStmt) -> TypeCheckerResult<()> {
+        let ty = self.visit_expr(&switch_stmt.cond)?;
+        if ty != Type::Int {
+            return Err(TypeCheckerError {
+                token: switch_stmt.cond.1.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: Type::Int,
+                    got: ty,
+                },
+            });
+        }
+
+        for case in &switch_stmt.cases {
+            self.visit_compound(&case.stmt)?;
+        }
+        self.visit_compound(&switch_stmt.default)?;
+
+        Ok(())
+    }
+
+    fn visit_while(&mut self, while_stmt: &WhileStmt) -> TypeCheckerResult<()> {
+        let ty = self.visit_expr(&while_stmt.cond)?;
+        if ty != Type::Int {
+            return Err(TypeCheckerError {
+                token: while_stmt.cond.1.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: Type::Int,
+                    got: ty,
+                },
+            });
+        }
+
+        self.visit_stmt(&while_stmt.body)?;
+        Ok(())
+    }
+}
+
+impl ASTRefVisitor for TypeChecker {
+    type BlockItemResult = TypeCheckerResult<()>;
+    type ExprResult = TypeCheckerResult<Type>;
+    type FuncDeclResult = TypeCheckerResult<()>;
+    type ProgramResult = TypeCheckerResult<()>;
+    type StmtResult = TypeCheckerResult<()>;
+    type VarDeclResult = TypeCheckerResult<()>;
+
+    fn visit_block_item(&mut self, block_item: &BlockItem) -> Self::BlockItemResult {
+        match block_item {
+            BlockItem::FunctionDecl(func_decl) => self.visit_function_decl(func_decl)?,
+            BlockItem::Stmt(stmt) => self.visit_stmt(stmt)?,
+            BlockItem::VarDecl(var_decl) => {
+                for decl in var_decl {
+                    self.visit_var_decl(decl)?;
+                }
+            }
+        };
+
+        Ok(())
+    }
+
+    fn visit_function_decl(&mut self, function_def: &FunctionDecl) -> Self::FuncDeclResult {
+        self.add_symbol(
+            function_def.name.0.clone(),
+            Type::Function {
+                params: function_def.params.iter().map(|_| Type::Int).collect(),
+            },
+        );
+
+        if let Some(ref body) = function_def.body {
+            self.visit_compound(body)?;
+        }
+
+        Ok(())
+    }
+
+    fn visit_program(&mut self, program: &Program) -> Self::ProgramResult {
+        for function_decl in &program.0 {
+            self.visit_function_decl(function_decl)?;
+        }
+        Ok(())
+    }
+
+    fn visit_var_decl(&mut self, var_decl: &VarDecl) -> Self::VarDeclResult {
+        let ty = self.visit_expr(var_decl.init.as_ref().unwrap())?;
+        if ty != var_decl.ty {
+            Err(TypeCheckerError {
+                token: var_decl.name.1.clone(),
+                kind: TypeCheckerErrorKind::TypeMismatch {
+                    expected: var_decl.ty.clone(),
+                    got: ty,
+                },
+            })
+        } else {
+            self.add_symbol(var_decl.name.0.clone(), ty);
+            Ok(())
+        }
+    }
+}

--- a/src/type_checker/symbol_table.rs
+++ b/src/type_checker/symbol_table.rs
@@ -1,0 +1,14 @@
+use std::collections::HashMap;
+
+use crate::lexer::token::Token;
+
+use super::r#type::Type;
+
+#[derive(Debug)]
+pub struct SymbolTableEntry {
+    pub ty: Type,
+    pub token: Token,
+    pub defined: bool,
+}
+
+pub type SymbolTable = HashMap<String, SymbolTableEntry>;

--- a/src/type_checker/type.rs
+++ b/src/type_checker/type.rs
@@ -1,0 +1,24 @@
+use std::fmt::Display;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Type {
+    Int,
+    Function { params: Vec<Type> },
+}
+
+impl Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Type::Int => write!(f, "int"),
+            Type::Function { params } => write!(
+                f,
+                "fn({})",
+                params
+                    .iter()
+                    .map(|p| p.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a preliminary type-checker, support for specific types of functions, and compilation and linking of multiple translation units.

### Changes in the compilation process
* Added a `tacky_gen` feature to conditionally compile to TACKY.
* Added option to pass multiple files for compilation in the driver (compiles each to an object file, then uses `gcc` to link them).
* Added option `-c` to compile input files to object files.

### Support for functions
* Each entry in the symbol table in the `Resolver` now has a `linkage` field, which describes the `linkage` of the variable (currently functions have the `Linkage::Internal` linkage, and normal variables have `Linkage::None`)
* Functions returning an `int` and taking either zero or only `int ` arguments can be declared and defined (definition can only occur at the top level).
* According to the x64 ABI, the first 6 arguments go into registers, and the rest into the stack. For ease of implementation, currently, all arguments are recopied onto the function stack. 
* Allocation of the stack has been changed to align the stack of every function to 16 bits.
* Added instructions in the TACKY and ASM stage for function calls, deallocating stack and pushing to the stack.

### Type Checker
* Added a `type_checker` module
* The `TypeChecker` struct implements the `ASTRefVisitor` and its dependencies.
* Only supports `int` and function types (since function pointers don't exist, the function types cannot actually be used in a C program)
* Raises `TypeCheckerError` errors